### PR TITLE
Requested upstream changes

### DIFF
--- a/providers/freebsd/host_freebsd_cgo.go
+++ b/providers/freebsd/host_freebsd_cgo.go
@@ -128,11 +128,10 @@ func (r *reader) memInfo(m *types.HostMemoryInfo) {
 	//   free = free
 	//   available = buffers + inactive + cache + free
 
-	ps, err := pageSizeBytes()
+	pageSize, err := pageSizeBytes()
 	if r.addErr(err) {
 		return
 	}
-	pageSize := uint64(ps)
 
 	m.Total, err = totalPhysicalMem()
 	if r.addErr(err) {
@@ -144,31 +143,31 @@ func (r *reader) memInfo(m *types.HostMemoryInfo) {
 		return
 	}
 	m.Metrics = make(map[string]uint64, 6)
-	m.Metrics["active_bytes"] = uint64(activePages) * pageSize
+	m.Metrics["active_bytes"] = activePages * pageSize
 
 	wirePages, err := wirePageCount()
 	if r.addErr(err) {
 		return
 	}
-	m.Metrics["wired_bytes"] = uint64(wirePages) * pageSize
+	m.Metrics["wired_bytes"] = wirePages * pageSize
 
 	inactivePages, err := inactivePageCount()
 	if r.addErr(err) {
 		return
 	}
-	m.Metrics["inactive_bytes"] = uint64(inactivePages) * pageSize
+	m.Metrics["inactive_bytes"] = inactivePages * pageSize
 
 	cachePages, err := cachePageCount()
 	if r.addErr(err) {
 		return
 	}
-	m.Metrics["cache_bytes"] = uint64(cachePages) * pageSize
+	m.Metrics["cache_bytes"] = cachePages * pageSize
 
 	freePages, err := freePageCount()
 	if r.addErr(err) {
 		return
 	}
-	m.Metrics["free_bytes"] = uint64(freePages) * pageSize
+	m.Metrics["free_bytes"] = freePages * pageSize
 
 	buffers, err := buffersUsedBytes()
 	if r.addErr(err) {
@@ -176,9 +175,9 @@ func (r *reader) memInfo(m *types.HostMemoryInfo) {
 	}
 	m.Metrics["buffer_bytes"] = buffers
 
-	m.Used = uint64(activePages+wirePages) * pageSize
-	m.Free = uint64(freePages) * pageSize
-	m.Available = uint64(inactivePages+cachePages+freePages)*pageSize + buffers
+	m.Used = (activePages + wirePages) * pageSize
+	m.Free = freePages * pageSize
+	m.Available = (inactivePages+cachePages+freePages)*pageSize + buffers
 
 	// Virtual (swap) Memory
 	swap, err := kvmGetSwapInfo()

--- a/providers/freebsd/host_freebsd_cgo.go
+++ b/providers/freebsd/host_freebsd_cgo.go
@@ -107,10 +107,7 @@ func (r *reader) addErr(err error) bool {
 }
 
 func (r *reader) Err() error {
-	if len(r.errs) > 0 {
-		return errors.Join(r.errs...)
-	}
-	return nil
+	return errors.Join(r.errs...)
 }
 
 func (r *reader) cpuTime(cpu *types.CPUTimes) {

--- a/providers/freebsd/host_freebsd_cgo.go
+++ b/providers/freebsd/host_freebsd_cgo.go
@@ -133,46 +133,25 @@ func (r *reader) memInfo(m *types.HostMemoryInfo) {
 		return
 	}
 
-	m.Total, err = totalPhysicalMem()
-	if r.addErr(err) {
-		return
-	}
+	m.Total = totalPhysicalMem(r)
+	activePages := activePageCount(r)
 
-	activePages, err := activePageCount()
-	if r.addErr(err) {
-		return
-	}
 	m.Metrics = make(map[string]uint64, 6)
 	m.Metrics["active_bytes"] = activePages * pageSize
 
-	wirePages, err := wirePageCount()
-	if r.addErr(err) {
-		return
-	}
+	wirePages := wirePageCount(r)
 	m.Metrics["wired_bytes"] = wirePages * pageSize
 
-	inactivePages, err := inactivePageCount()
-	if r.addErr(err) {
-		return
-	}
+	inactivePages := inactivePageCount(r)
 	m.Metrics["inactive_bytes"] = inactivePages * pageSize
 
-	cachePages, err := cachePageCount()
-	if r.addErr(err) {
-		return
-	}
+	cachePages := cachePageCount(r)
 	m.Metrics["cache_bytes"] = cachePages * pageSize
 
-	freePages, err := freePageCount()
-	if r.addErr(err) {
-		return
-	}
+	freePages := freePageCount(r)
 	m.Metrics["free_bytes"] = freePages * pageSize
 
-	buffers, err := buffersUsedBytes()
-	if r.addErr(err) {
-		return
-	}
+	buffers := buffersUsedBytes(r)
 	m.Metrics["buffer_bytes"] = buffers
 
 	m.Used = (activePages + wirePages) * pageSize

--- a/providers/freebsd/process_freebsd_cgo.go
+++ b/providers/freebsd/process_freebsd_cgo.go
@@ -285,7 +285,7 @@ func (p *process) Memory() (types.MemoryInfo, error) {
 	p.kinfo = procs[0].kinfo
 
 	return types.MemoryInfo{
-		Resident: uint64(p.kinfo.ki_rssize) * uint64(pageSize),
+		Resident: uint64(p.kinfo.ki_rssize) * pageSize,
 		Virtual:  uint64(p.kinfo.ki_size),
 	}, nil
 }

--- a/providers/freebsd/sysctl_freebsd.go
+++ b/providers/freebsd/sysctl_freebsd.go
@@ -53,14 +53,14 @@ var pageSizeBytes = sync.OnceValues(func() (uint64, error) {
 	return uint64(v), nil
 })
 
-func activePageCount() (uint64, error) {
+func activePageCount(r *reader) uint64 {
 	const mib = "vm.stats.vm.v_active_count"
 
 	v, err := unix.SysctlUint32(mib)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get %s: %w", mib, err)
+	if r.addErr(err) {
+		return 0
 	}
-	return uint64(v), nil
+	return uint64(v)
 }
 
 func architecture() (string, error) {
@@ -87,26 +87,26 @@ func bootTime() (time.Time, error) {
 }
 
 // buffersUsedBytes returns the number memory bytes used as disk cache.
-func buffersUsedBytes() (uint64, error) {
+func buffersUsedBytes(r *reader) uint64 {
 	const mib = "vfs.bufspace"
 
 	v, err := unix.SysctlUint64(mib)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get %s: %w", mib, err)
+	if r.addErr(err) {
+		return 0
 	}
 
-	return v, nil
+	return v
 }
 
-func cachePageCount() (uint64, error) {
+func cachePageCount(r *reader) uint64 {
 	const mib = "vm.stats.vm.v_cache_count"
 
 	v, err := unix.SysctlUint32(mib)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get %s: %w", mib, err)
+	if r.addErr(err) {
+		return 0
 	}
 
-	return uint64(v), nil
+	return uint64(v)
 }
 
 const sizeOfUint64 = int(unsafe.Sizeof(uint64(0)))
@@ -143,26 +143,26 @@ func cpuStateTimes() (*types.CPUTimes, error) {
 	}, nil
 }
 
-func freePageCount() (uint64, error) {
+func freePageCount(r *reader) uint64 {
 	const mib = "vm.stats.vm.v_free_count"
 
 	v, err := unix.SysctlUint32(mib)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get %s: %w", mib, err)
+	if r.addErr(err) {
+		return 0
 	}
 
-	return uint64(v), nil
+	return uint64(v)
 }
 
-func inactivePageCount() (uint64, error) {
+func inactivePageCount(r *reader) uint64 {
 	const mib = "vm.stats.vm.v_inactive_count"
 
 	v, err := unix.SysctlUint32(mib)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get %s: %w", mib, err)
+	if r.addErr(err) {
+		return 0
 	}
 
-	return uint64(v), nil
+	return uint64(v)
 }
 
 func kernelVersion() (string, error) {
@@ -227,22 +227,22 @@ func operatingSystem() (*types.OSInfo, error) {
 	return info, nil
 }
 
-func totalPhysicalMem() (uint64, error) {
+func totalPhysicalMem(r *reader) uint64 {
 	const mib = "hw.physmem"
 
 	v, err := unix.SysctlUint64(mib)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get %s: %w", mib, err)
+	if r.addErr(err) {
+		return 0
 	}
-	return v, nil
+	return v
 }
 
-func wirePageCount() (uint64, error) {
+func wirePageCount(r *reader) uint64 {
 	const mib = "vm.stats.vm.v_wire_count"
 
 	v, err := unix.SysctlUint32(mib)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get %s: %w", mib, err)
+	if r.addErr(err) {
+		return 0
 	}
-	return uint64(v), nil
+	return uint64(v)
 }

--- a/providers/freebsd/sysctl_freebsd.go
+++ b/providers/freebsd/sysctl_freebsd.go
@@ -120,7 +120,7 @@ func cpuStateTimes() (*types.CPUTimes, error) {
 	}
 
 	const mib = "kern.cp_time"
-	buf, err := unix.SysctlRaw("kern.cp_time")
+	buf, err := unix.SysctlRaw(mib)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get %s: %w", mib, err)
 	}

--- a/providers/freebsd/sysctl_freebsd.go
+++ b/providers/freebsd/sysctl_freebsd.go
@@ -42,7 +42,7 @@ var tickDuration = sync.OnceValues(func() (time.Duration, error) {
 	return time.Duration(c.Tick) * time.Microsecond, nil
 })
 
-var pageSizeBytes = sync.OnceValues(func() (uint32, error) {
+var pageSizeBytes = sync.OnceValues(func() (uint64, error) {
 	const mib = "vm.stats.vm.v_page_size"
 
 	v, err := unix.SysctlUint32(mib)
@@ -50,17 +50,17 @@ var pageSizeBytes = sync.OnceValues(func() (uint32, error) {
 		return 0, fmt.Errorf("failed to get %s: %w", mib, err)
 	}
 
-	return v, nil
+	return uint64(v), nil
 })
 
-func activePageCount() (uint32, error) {
+func activePageCount() (uint64, error) {
 	const mib = "vm.stats.vm.v_active_count"
 
 	v, err := unix.SysctlUint32(mib)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get %s: %w", mib, err)
 	}
-	return v, nil
+	return uint64(v), nil
 }
 
 func architecture() (string, error) {
@@ -98,7 +98,7 @@ func buffersUsedBytes() (uint64, error) {
 	return v, nil
 }
 
-func cachePageCount() (uint32, error) {
+func cachePageCount() (uint64, error) {
 	const mib = "vm.stats.vm.v_cache_count"
 
 	v, err := unix.SysctlUint32(mib)
@@ -106,7 +106,7 @@ func cachePageCount() (uint32, error) {
 		return 0, fmt.Errorf("failed to get %s: %w", mib, err)
 	}
 
-	return v, nil
+	return uint64(v), nil
 }
 
 const sizeOfUint64 = int(unsafe.Sizeof(uint64(0)))
@@ -143,7 +143,7 @@ func cpuStateTimes() (*types.CPUTimes, error) {
 	}, nil
 }
 
-func freePageCount() (uint32, error) {
+func freePageCount() (uint64, error) {
 	const mib = "vm.stats.vm.v_free_count"
 
 	v, err := unix.SysctlUint32(mib)
@@ -151,10 +151,10 @@ func freePageCount() (uint32, error) {
 		return 0, fmt.Errorf("failed to get %s: %w", mib, err)
 	}
 
-	return v, nil
+	return uint64(v), nil
 }
 
-func inactivePageCount() (uint32, error) {
+func inactivePageCount() (uint64, error) {
 	const mib = "vm.stats.vm.v_inactive_count"
 
 	v, err := unix.SysctlUint32(mib)
@@ -162,7 +162,7 @@ func inactivePageCount() (uint32, error) {
 		return 0, fmt.Errorf("failed to get %s: %w", mib, err)
 	}
 
-	return v, nil
+	return uint64(v), nil
 }
 
 func kernelVersion() (string, error) {
@@ -237,12 +237,12 @@ func totalPhysicalMem() (uint64, error) {
 	return v, nil
 }
 
-func wirePageCount() (uint32, error) {
+func wirePageCount() (uint64, error) {
 	const mib = "vm.stats.vm.v_wire_count"
 
 	v, err := unix.SysctlUint32(mib)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get %s: %w", mib, err)
 	}
-	return v, nil
+	return uint64(v), nil
 }

--- a/providers/freebsd/sysctl_freebsd_test.go
+++ b/providers/freebsd/sysctl_freebsd_test.go
@@ -102,6 +102,7 @@ func TestMachineID(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, machineID)
+	assert.Regexp(t, "^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$", machineID)
 }
 
 func TestOperatingSystem(t *testing.T) {

--- a/providers/freebsd/sysctl_freebsd_test.go
+++ b/providers/freebsd/sysctl_freebsd_test.go
@@ -35,6 +35,7 @@ func TestArchitecture(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, arch)
+	assert.Regexp(t, `(amd64|i386|powerpc(64(le)?|spe)?|armv(6|7)|aarch64|riscv64*|mips(n)?(32|64)?(el)?|sparc64)`, arch)
 }
 
 func TestBootTime(t *testing.T) {

--- a/providers/freebsd/sysctl_freebsd_test.go
+++ b/providers/freebsd/sysctl_freebsd_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 )
@@ -92,7 +93,18 @@ func TestKernelVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Retrieve currently running kernel version
+	cmd := exec.Command("/bin/freebsd-version", "-r")
+	fbsdout, err := cmd.Output()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fbsdver := strings.TrimSuffix(string(fbsdout), "\n")
+
 	assert.NotEmpty(t, kernel)
+	assert.EqualValues(t, kernel, fbsdver)
 }
 
 func TestMachineID(t *testing.T) {

--- a/providers/freebsd/sysctl_freebsd_test.go
+++ b/providers/freebsd/sysctl_freebsd_test.go
@@ -36,7 +36,7 @@ func TestArchitecture(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, arch)
-	assert.Regexp(t, `(amd64|i386|powerpc(64(le)?|spe)?|armv(6|7)|aarch64|riscv64*|mips(n)?(32|64)?(el)?|sparc64)`, arch)
+	assert.Regexp(t, `(amd64|i386|powerpc|arm(64)?|riscv|mips|sparc64|pc98)`, arch)
 }
 
 func TestBootTime(t *testing.T) {


### PR DESCRIPTION
This PR addresses the following requests:

- TestBootTime() compares with the system `uptime` binary output
- Moves the various sysctl integer casts/conversions into their respective helper methods 
- Changed how memInfo() values are collected
- Added additional validations to the tests